### PR TITLE
add missing netTimeout to Connection-constructor params

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -119,6 +119,7 @@ Client.prototype.getHostList = function() {
         connections[host] = new Connection({
             host: h.host,
             port: h.port,
+            netTimeout: this.netTimeout,
             reconnect: false,
             onConnect: function() {
                 // Do the autodiscovery, then resolve with hosts
@@ -165,6 +166,7 @@ Client.prototype.connectToHosts = function() {
                 client.flushBuffer();
             },
             bufferBeforeError: this.bufferBeforeError,
+            netTimeout: this.netTimeout,
             onError: this.onNetError,
             maxValueSize: this.maxValueSize
         }));


### PR DESCRIPTION
This is missing from memcache-plus and will allow to make connections to a memcached-server with netTimeout. Currently it defaults to 500ms (which is rather low IMHO...)